### PR TITLE
Changes in lua-gsl makefile because GSL include directory was not found ...

### DIFF
--- a/lua-gsl/Makefile
+++ b/lua-gsl/Makefile
@@ -25,7 +25,7 @@ include $(GSH_BASE_DIR)/make-system-detect
 include $(GSH_BASE_DIR)/makepackages
 include $(GSH_BASE_DIR)/makedefs
 
-INCLUDES += -I$(GSH_BASE_DIR)
+INCLUDES += -I$(GSH_BASE_DIR) $(GSL_INCLUDES)
 LIBS += $(PTHREAD_LIBS)
 DEFS += $(PTHREAD_DEFS) $(GSL_SHELL_DEFS)
 CFLAGS += $(LUA_CFLAGS)


### PR DESCRIPTION
...during make.

I tried to make it on my Linux machine and it could not find the gsl include directory when compiling the lua-gsl sub library. I fixed it by readding the GSL_INCLUDES in the local Makefile, though there might be other solutions for this.
